### PR TITLE
Remove jenkins reporter from test config

### DIFF
--- a/test/index.ts
+++ b/test/index.ts
@@ -22,7 +22,6 @@ if (!tty.getWindowSize) {
 }
 
 let mocha = new Mocha({
-    reporter: 'mocha-jenkins-reporter',
     ui: 'tdd',
     useColors: true,
     timeout: 15000


### PR DESCRIPTION
The reporter is only supposed to work on jenkins, besides it breaks travis - so just let jenkins inject it