### PR TITLE
Refactor activate method into smaller parts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ out
 node_modules
 .vscode-test/
 *.vsix
-org.jboss.tools.ssp.distribution-0.0.9-SNAPSHOT.zip
+*.zip
 server
 coverage/
 

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -1,0 +1,152 @@
+import { ServerInfo } from './server';
+import { ServersViewTreeDataProvider } from './serverExplorer';
+import * as vscode from 'vscode';
+import { Protocol, RSPClient, ServerState } from 'rsp-client';
+
+export interface ExtensionAPI {
+    readonly serverInfo: ServerInfo;
+}
+
+export class CommandHandler {
+
+    private client: RSPClient;
+    private serversData: ServersViewTreeDataProvider;
+
+    constructor(serversData: ServersViewTreeDataProvider, client: RSPClient) {
+        this.client = client;
+        this.serversData = serversData;
+    }
+
+    async startServer(mode: string, context?: any): Promise<Protocol.StartServerResponse> {
+        let selectedServerType: Protocol.ServerType;
+        let selectedServerId: string;
+
+        if (context === undefined) {
+            selectedServerId = await vscode.window.showQuickPick(Array.from(this.serversData.servers.keys()),
+                { placeHolder: 'Select runtime/server to start' });
+            selectedServerType = this.serversData.servers.get(selectedServerId).type;
+        } else {
+            selectedServerType = context.type;
+            selectedServerId = context.id;
+        }
+
+        if (this.serversData.serverStatus.get(selectedServerId) === ServerState.STOPPED) {
+            const response = await this.client.startServerAsync({
+                params: {
+                    serverType: selectedServerType.id,
+                    id: selectedServerId,
+                    attributes: new Map<string, any>()
+                },
+                mode: mode
+            });
+            if (response.status.severity > 0) {
+                return Promise.reject(response.status.message);
+            }
+            return response;
+        } else {
+            return Promise.reject('The server is already running.');
+        }
+    }
+
+    async stopServer(context?: any): Promise<Protocol.Status> {
+        let serverId: string;
+        if (context === undefined) {
+            serverId = await vscode.window.showQuickPick(Array.from(this.serversData.servers.keys()),
+                { placeHolder: 'Select runtime/server to stop' });
+        } else {
+            serverId = context.id;
+        }
+
+        if (this.serversData.serverStatus.get(serverId) === ServerState.STARTED) {
+            const status = await this.client.stopServerAsync({ id: serverId, force: true });
+            if (status.severity > 0) {
+                return Promise.reject(status.message);
+            }
+            return status;
+        } else {
+            return Promise.reject('The server is already stopped.');
+        }
+    }
+
+    async removeServer(context?: any): Promise<Protocol.Status> {
+        let serverId: string;
+        let selectedServerType: Protocol.ServerType;
+        if (context === undefined) {
+            serverId = await vscode.window.showQuickPick(Array.from(this.serversData.servers.keys()),
+                { placeHolder: 'Select runtime/server to remove' });
+            selectedServerType = this.serversData.servers.get(serverId).type;
+        } else {
+            serverId = context.id;
+            selectedServerType = context.type;
+        }
+
+        if (this.serversData.serverStatus.get(serverId) === ServerState.STOPPED) {
+            const status = await this.client.deleteServerAsync({ id: serverId, type: selectedServerType });
+            if (status.severity > 0) {
+                return Promise.reject(status.message);
+            }
+            return status;
+        } else {
+            return Promise.reject('Please stop the server before removing it.');
+        }
+    }
+
+    async showServerOutput(context?: any): Promise<void> {
+        if (context === undefined) {
+            const serverId = await vscode.window.showQuickPick(Array.from(this.serversData.servers.keys()),
+                { placeHolder: 'Select runtime/server to show ouput channel' });
+            context = this.serversData.servers.get(serverId);
+        }
+        this.serversData.showOutput(context);
+    }
+
+    async restartServer(context?: any): Promise<void> {
+        if (context === undefined) {
+            const serverId: string = await vscode.window.showQuickPick(
+                Array.from(this.serversData.servers.keys())
+                .filter(item => this.serversData.serverStatus.get(item) === ServerState.STARTED),
+                { placeHolder: 'Select runtime/server to restart' }
+            );
+            context = this.serversData.servers.get(serverId);
+        }
+
+        const params: Protocol.LaunchParameters = {
+            mode: 'run',
+            params: {
+                id: context.id,
+                serverType: context.type.id,
+                attributes: new Map<string, any>()
+            }
+        };
+
+        await this.client.stopServerSync({ id: context.id, force: true });
+        await this.client.startServerAsync(params);
+    }
+
+    async addLocation(): Promise<Protocol.Status> {
+        if (this.serversData) {
+            return this.serversData.addLocation();
+        } else {
+            return Promise.reject('Stack Protocol Server is starting, please try again later.');
+        }
+    }
+
+    async activate(): Promise<void> {
+        await this.client.connect();
+        this.client.onServerAdded(handle => {
+            this.serversData.insertServer(handle);
+        });
+
+        this.client.onServerRemoved(handle => {
+            this.serversData.removeServer(handle);
+        });
+
+        this.client.onServerStateChange(event => {
+            this.serversData.updateServer(event);
+        });
+
+        this.client.onServerOutputAppended(event => {
+            this.serversData.addServerOutput(event);
+        });
+    }
+}

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -1,0 +1,353 @@
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+import * as vscode from 'vscode';
+import { ServersViewTreeDataProvider } from '../src/serverExplorer';
+import { RSPClient, ServerState, Protocol } from 'rsp-client';
+import { CommandHandler } from '../src/extensionApi';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Command Handler', () => {
+    let sandbox: sinon.SinonSandbox;
+    let client: RSPClient;
+    let handler: CommandHandler;
+    let serverExplorer: ServersViewTreeDataProvider;
+
+    const serverType: Protocol.ServerType = {
+        id: 'type',
+        description: 'a type',
+        visibleName: 'the type'
+    };
+
+    const serverHandle: Protocol.ServerHandle = {
+        id: 'id',
+        type: serverType
+    };
+
+    const status: Protocol.Status = {
+        code: 0,
+        message: 'ok',
+        severity: 0,
+        ok: true,
+        plugin: 'unknown',
+        trace: ''
+    };
+
+    const errorStatus: Protocol.Status = {
+        code: 0,
+        message: 'Critical Error',
+        ok: false,
+        plugin: 'plugin',
+        severity: 4,
+        trace: ''
+    };
+
+    const simpleContext = {
+        id: 'cid'
+    };
+    const context = {
+        id: 'cid',
+        type: serverType
+    };
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        client = new RSPClient('localhost', 27155);
+        serverExplorer = new ServersViewTreeDataProvider(client);
+        handler = new CommandHandler(serverExplorer, client);
+
+        sandbox.stub(client, 'connect').resolves();
+        sandbox.stub(serverExplorer);
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('activate connects to the server', async () => {
+        await handler.activate();
+
+        expect(client.connect).calledOnce;
+    });
+
+    test('activate registers event listeners', async () => {
+        sandbox.spy(client, 'onServerAdded');
+        sandbox.spy(client, 'onServerRemoved');
+        sandbox.spy(client, 'onServerStateChange');
+        sandbox.spy(client, 'onServerOutputAppended');
+
+        await handler.activate();
+
+        expect(client.onServerAdded).calledOnce;
+        expect(client.onServerRemoved).calledOnce;
+        expect(client.onServerStateChange).calledOnce;
+        expect(client.onServerOutputAppended).calledOnce;
+    });
+
+    suite('startServer', () => {
+        let statusStub: sinon.SinonStub;
+        let startStub: sinon.SinonStub;
+
+        const cmdDetails: Protocol.CommandLineDetails = {
+            cmdLine: [''],
+            envp: [],
+            properties: {},
+            workingDir: 'dir'
+        };
+
+        const response: Protocol.StartServerResponse = {
+            details: cmdDetails,
+            status: status
+        };
+
+        setup(() => {
+            statusStub = sandbox.stub(serverExplorer.serverStatus, 'get').returns(ServerState.STOPPED);
+            startStub = sandbox.stub(client, 'startServerAsync').resolves(response);
+        });
+
+        test('works with injected context', async () => {
+            const result = await handler.startServer('run', context);
+            const args: Protocol.LaunchParameters = {
+                mode: 'run',
+                params: {
+                    serverType: context.type.id,
+                    id: context.id,
+                    attributes: new Map<string, any>()
+                }
+            }
+
+            expect(result).equals(response);
+            expect(startStub).calledOnceWith(args);
+        });
+
+        test('works without injected context', async () => {
+            sandbox.stub(vscode.window, 'showQuickPick').resolves('id');
+            sandbox.stub(serverExplorer.servers, 'get').returns(serverHandle);
+
+            const result = await handler.startServer('run');
+            const args: Protocol.LaunchParameters = {
+                mode: 'run',
+                params: {
+                    serverType: serverType.id,
+                    id: 'id',
+                    attributes: new Map<string, any>()
+                }
+            }
+
+            expect(result).equals(response);
+            expect(startStub).calledOnceWith(args);
+        });
+
+        test('errors if the server is already running', async () => {
+            statusStub.returns(ServerState.STARTED);
+
+            try {
+                await handler.startServer('run', context);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals('The server is already running.');
+            }
+        });
+
+        test('throws any errors coming from the rsp client', async () => {
+            const result: Protocol.StartServerResponse = {
+                details: cmdDetails,
+                status: errorStatus
+            };
+            startStub.resolves(result);
+
+            try {
+                await handler.startServer('run', context);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals(errorStatus.message);
+            }
+        });
+    });
+
+    suite('stopServer', () => {
+        let statusStub: sinon.SinonStub;
+        let stopStub: sinon.SinonStub;
+
+        setup(() => {
+            statusStub = sandbox.stub(serverExplorer.serverStatus, 'get').returns(ServerState.STARTED);
+            stopStub = sandbox.stub(client, 'stopServerAsync').resolves(status);
+            sandbox.stub(vscode.window, 'showQuickPick').resolves('id');
+        });
+
+        test('works with injected context', async () => {
+            const result = await handler.stopServer(simpleContext);
+            const args: Protocol.StopServerAttributes = {
+                id: simpleContext.id,
+                force: true
+            };
+
+            expect(result).equals(status);
+            expect(stopStub).calledOnceWith(args);
+        });
+
+        test('works without injected context', async () => {
+            const result = await handler.stopServer();
+            const args: Protocol.StopServerAttributes = {
+                id: 'id',
+                force: true
+            };
+
+            expect(result).equals(status);
+            expect(stopStub).calledOnceWith(args);
+        });
+
+        test('errors if the server is already stopped', async () => {
+            statusStub.returns(ServerState.STOPPED);
+
+            try {
+                await handler.stopServer(simpleContext);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals('The server is already stopped.');
+            }
+        });
+
+        test('throws any errors coming from the rsp client', async () => {
+            stopStub.resolves(errorStatus);
+
+            try {
+                await handler.stopServer(simpleContext);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals(errorStatus.message);
+            }
+        });
+    });
+
+    suite('removeServer', () => {
+        let statusStub: sinon.SinonStub;
+        let removeStub: sinon.SinonStub;
+
+        setup(() => {
+            statusStub = sandbox.stub(serverExplorer.serverStatus, 'get').returns(ServerState.STOPPED);
+            removeStub = sandbox.stub(client, 'deleteServerAsync').resolves(status);
+            sandbox.stub(vscode.window, 'showQuickPick').resolves('id');
+        });
+
+        test('works with injected context', async () => {
+            const result = await handler.removeServer(context);
+            const args: Protocol.ServerHandle = {
+                id: context.id,
+                type: context.type
+            };
+
+            expect(result).equals(status);
+            expect(removeStub).calledOnceWith(args);
+        });
+
+        test('works without injected context', async () => {
+            sandbox.stub(serverExplorer.servers, 'get').returns(serverHandle);
+            const result = await handler.removeServer();
+            const args: Protocol.ServerHandle = {
+                id: 'id',
+                type: serverType
+            };
+
+            expect(result).equals(status);
+            expect(removeStub).calledOnceWith(args);
+        });
+
+        test('errors if the server is not stopped', async () => {
+            statusStub.returns(ServerState.STARTED);
+
+            try {
+                await handler.removeServer(context);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals('Please stop the server before removing it.');
+            }
+        });
+
+        test('throws any errors coming from the rsp client', async () => {
+            removeStub.resolves(errorStatus);
+
+            try {
+                await handler.removeServer(context);
+                expect.fail();
+            } catch (err) {
+                expect(err).equals(errorStatus.message);
+            }
+        });
+    });
+
+    suite('restartServer', () => {
+        let startStub: sinon.SinonStub;
+        let stopStub: sinon.SinonStub;
+
+        setup(() => {
+            sandbox.stub(serverExplorer.serverStatus, 'get').returns(ServerState.STARTED);
+            startStub = sandbox.stub(client, 'startServerAsync').resolves(status);
+            stopStub = sandbox.stub(client, 'stopServerSync').resolves(status);
+            sandbox.stub(vscode.window, 'showQuickPick').resolves('id');
+        });
+
+        test('works with injected context', async () => {
+            await handler.restartServer(context);
+            const stopArgs: Protocol.StopServerAttributes = {
+                id: context.id,
+                force: true
+            };
+            const startArgs: Protocol.LaunchParameters = {
+                mode: 'run',
+                params: {
+                    id: context.id,
+                    serverType: context.type.id,
+                    attributes: new Map<string, any>()
+                }
+            };
+
+            expect(stopStub).calledOnceWith(stopArgs);
+            expect(startStub).calledAfter(stopStub);
+            expect(startStub).calledOnceWith(startArgs);
+        });
+
+        test('works without injected context', async () => {
+            sandbox.stub(serverExplorer.servers, 'get').returns(serverHandle);
+            await handler.restartServer();
+            const stopArgs: Protocol.StopServerAttributes = {
+                id: 'id',
+                force: true
+            };
+            const startArgs: Protocol.LaunchParameters = {
+                mode: 'run',
+                params: {
+                    id: 'id',
+                    serverType: serverType.id,
+                    attributes: new Map<string, any>()
+                }
+            };
+
+            expect(stopStub).calledOnceWith(stopArgs);
+            expect(startStub).calledAfter(stopStub);
+            expect(startStub).calledOnceWith(startArgs);
+        });
+    });
+
+    suite('addLocation', () => {
+
+        test('calls addLocation from server explorer', async () => {
+            await handler.addLocation();
+
+            expect(serverExplorer.addLocation).calledOnce;
+        });
+
+        test('errors if server explorer is not initialized', async () => {
+            const nullHandler = new CommandHandler(null, client);
+
+            try {
+                await nullHandler.addLocation();
+                expect.fail();
+            } catch (err) {
+                expect(err).equals('Stack Protocol Server is starting, please try again later.');
+            }
+        });
+    });
+});

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,26 +1,10 @@
-
-// The module 'assert' provides assertion methods from node
 import * as assert from 'assert';
 import * as vscode from 'vscode';
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
-// import * as vscode from 'vscode';
-// import * as myExtension from '../extension';
 
-// Defines a Mocha test suite to group tests of similar kind together
 suite('Extension Tests', function() {
     let connection;
-    suiteSetup(function(done) {
-        setTimeout(function() {
-            try {
-                vscode.extensions.getExtension('redhat.vscode-adapters').exports.start.then(connInfo => {
-                    connection = connInfo;
-                    done();
-                });
-            } catch (e) {
-                done(new Error(e));
-            }
-        }, 1000);
+    suiteSetup(async () => {
+        connection = await vscode.extensions.getExtension('redhat.vscode-adapters').activate();
     });
 
     test('Server is started at extension activation time', function() {

--- a/test/serverExplorer.test.ts
+++ b/test/serverExplorer.test.ts
@@ -238,12 +238,15 @@ suite('Server explorer', () => {
             expect(createServerStub).calledOnceWith(serverBean, 'eap');
         });
 
-        test('should show message if no server detected in provided location', async () => {
+        test('should error if no server detected in provided location', async () => {
             findServerStub.resolves(null);
-            const infoStub = sandbox.stub(window, 'showInformationMessage');
-            await serverExplorer.addLocation();
 
-            expect(infoStub).calledOnceWith('Cannot detect server in selected location!');
+            try {
+                await serverExplorer.addLocation();
+                expect.fail();
+            } catch (err) {
+                expect(err).equals('Cannot detect server in selected location!');
+            }
         });
     });
 });


### PR DESCRIPTION
Addresses #164
 - move command declarations from activate() into a new class as new methods
 - unify server explorer method return types with thenables/promises
 - propagate errors (rejections) from commands to UI
 - tests, tests, tests