### PR TITLE
Make deployables commands work from the command palette

### DIFF
--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -164,6 +164,7 @@ export class CommandHandler {
                 return value.reference.label;
             });
             deploymentId = await vscode.window.showQuickPick(deployables, { placeHolder: 'Select deployment to remove' });
+            if (!deploymentId) return null;
         } else {
             serverId = context.server.id;
             deploymentId = context.reference.label;
@@ -187,7 +188,7 @@ export class CommandHandler {
     public async fullPublishServer(context?: Protocol.ServerState): Promise<Protocol.Status> {
         let serverId: string;
         if (context === undefined) {
-            serverId = await this.selectServer('Select runtime to publish');
+            serverId = await this.selectServer('Select server to publish');
             if (!serverId) return null;
         } else {
             serverId = context.server.id;
@@ -203,8 +204,8 @@ export class CommandHandler {
 
     public async createServer(): Promise<Protocol.Status> {
         this.assertServersDataExists();
-        const download: string = await vscode.window.showQuickPick(['Yes', 'No, use runtime on disk'],
-            { placeHolder: 'Download runtime?', ignoreFocusOut: true });
+        const download: string = await vscode.window.showQuickPick(['Yes', 'No, use server on disk'],
+            { placeHolder: 'Download server?', ignoreFocusOut: true });
         if (!download) {
             return;
         }
@@ -262,12 +263,10 @@ export class CommandHandler {
     }
 
     public async infoServer(context?: Protocol.ServerState): Promise<void> {
-
         if (context === undefined) {
             if (this.serversData) {
-                const serverId = await vscode.window.showQuickPick(Array.from(this.serversData.serverStatus.keys()),
-                { placeHolder: 'Select runtime/server you want to retrieve info about' });
-                if (!serverId) return Promise.reject('Please select a server from the Servers view.');
+                const serverId = await this.selectServer('Select server you want to retrieve info about');
+                if (!serverId) return null;
                 context = this.serversData.serverStatus.get(serverId);
             } else {
                 return Promise.reject('Runtime Server Protocol (RSP) Server is starting, please try again later.');
@@ -360,7 +359,7 @@ export class CommandHandler {
                 return newlist;
             });
         const answer = await vscode.window.showQuickPick(newlist,
-            { placeHolder: 'Please choose a runtime to download.' });
+            { placeHolder: 'Please choose a server to download.' });
         console.log(`${answer} was chosen`);
         if (!answer) {
             return null;

--- a/src/extensionApi.ts
+++ b/src/extensionApi.ts
@@ -18,6 +18,7 @@ export class CommandHandler {
 
     private client: RSPClient;
     private serversData: ServersViewTreeDataProvider;
+    private static readonly NO_SERVERS_FILTER: number = -1;
 
     constructor(serversData: ServersViewTreeDataProvider, client: RSPClient) {
         this.client = client;
@@ -29,8 +30,7 @@ export class CommandHandler {
         let selectedServerId: string;
 
         if (context === undefined) {
-            selectedServerId = await vscode.window.showQuickPick(Array.from(this.serversData.serverStatus.keys()),
-                { placeHolder: 'Select runtime/server to start' });
+            selectedServerId = await this.selectServer('Select server to start.');
             if (!selectedServerId) return null;
             selectedServerType = this.serversData.serverStatus.get(selectedServerId).server.type;
         } else {
@@ -60,8 +60,7 @@ export class CommandHandler {
     public async stopServer(context?: Protocol.ServerState): Promise<Protocol.Status> {
         let serverId: string;
         if (context === undefined) {
-            serverId = await vscode.window.showQuickPick(Array.from(this.serversData.serverStatus.keys()),
-                { placeHolder: 'Select runtime/server to stop' });
+            serverId = await this.selectServer('Select server to stop.');
             if (!serverId) return null;
         } else {
             serverId = context.server.id;
@@ -83,9 +82,7 @@ export class CommandHandler {
         let serverId: string;
         let selectedServerType: Protocol.ServerType;
         if (context === undefined) {
-            serverId = await vscode.window.showQuickPick(
-                Array.from(this.serversData.serverStatus.keys()),
-                { placeHolder: 'Select runtime/server to remove' });
+            serverId = await this.selectServer('Select server to remove');
             if (!serverId) return null;
             selectedServerType = this.serversData.serverStatus.get(serverId).server.type;
         } else {
@@ -112,8 +109,7 @@ export class CommandHandler {
 
     public async showServerOutput(context?: Protocol.ServerState): Promise<void> {
         if (context === undefined) {
-            const serverId = await vscode.window.showQuickPick(Array.from(this.serversData.serverStatus.keys()),
-                { placeHolder: 'Select runtime/server to show output channel' });
+            const serverId = await this.selectServer('Select server to show output channel');
             if (!serverId) return null;
             context = this.serversData.serverStatus.get(serverId);
         }
@@ -122,12 +118,7 @@ export class CommandHandler {
 
     public async restartServer(context?: Protocol.ServerState): Promise<void> {
         if (context === undefined) {
-            const serverId: string = await vscode.window.showQuickPick(
-                Array
-                  .from(this.serversData.serverStatus.keys())
-                  .filter(item => this.serversData.serverStatus.get(item).state === ServerState.STARTED),
-                    { placeHolder: 'Select runtime/server to restart' }
-            );
+            const serverId: string = await this.selectServer('Select server to restart', ServerState.STARTED);
             if (!serverId) return null;
             context = this.serversData.serverStatus.get(serverId);
         }
@@ -148,7 +139,8 @@ export class CommandHandler {
     public async addDeployment(context?: Protocol.ServerState): Promise<Protocol.Status> {
         let serverId: string;
         if (context === undefined) {
-            return Promise.reject('Please select a server from the Servers view.');
+            serverId = await this.selectServer('Select server to deploy to');
+            if (!serverId) return null;
         } else {
             serverId = context.server.id;
         }
@@ -162,18 +154,23 @@ export class CommandHandler {
     }
 
     public async removeDeployment(context?: Protocol.DeployableState): Promise<Protocol.Status> {
+        let serverId: string;
+        let deploymentId: string;
         if (context === undefined) {
-            return Promise.reject('Please select a deployment from the Servers view to run this action.');
-        }
+            serverId = await this.selectServer('Select server to remove deployment from');
+            if (!serverId) return null;
 
-        const serverId: string = context.server.id;
-        const deploymentId: string = context.reference.label;
+            const deployables = this.serversData.serverStatus.get(serverId).deployableStates.map(value => {
+                return value.reference.label;
+            });
+            deploymentId = await vscode.window.showQuickPick(deployables, { placeHolder: 'Select deployment to remove' });
+        } else {
+            serverId = context.server.id;
+            deploymentId = context.reference.label;
+        }
 
         if (this.serversData) {
             const serverState: Protocol.ServerState = this.serversData.serverStatus.get(serverId);
-            if (serverState === undefined) {
-                return Promise.reject('Please select a deployment from the Servers view to run this action.');
-            }
             const serverHandle: Protocol.ServerHandle = serverState.server;
             const states: Protocol.DeployableState[] = serverState.deployableStates;
             for (const entry of states) {
@@ -190,7 +187,8 @@ export class CommandHandler {
     public async fullPublishServer(context?: Protocol.ServerState): Promise<Protocol.Status> {
         let serverId: string;
         if (context === undefined) {
-            return Promise.reject('Please select a server from the Servers view.');
+            serverId = await this.selectServer('Select runtime to publish');
+            if (!serverId) return null;
         } else {
             serverId = context.server.id;
         }
@@ -284,6 +282,20 @@ export class CommandHandler {
         outputChannel.appendLine(`Server Name: ${selectedServerName}`);
         outputChannel.appendLine(`Server Type Id: ${selectedServerType.id}`);
         outputChannel.appendLine(`Server Description: ${selectedServerType.visibleName}`);
+    }
+
+    private async selectServer(message: string, stateFilter: number = CommandHandler.NO_SERVERS_FILTER): Promise<string> {
+        let servers = Array.from(this.serversData.serverStatus.keys());
+        if (stateFilter >= 0) {
+            servers = servers.filter(value => {
+                return this.serversData.serverStatus.get(value).state === stateFilter;
+            });
+        }
+        if (servers.length < 1) {
+            return Promise.reject('There are no servers to choose from.');
+        }
+
+        return vscode.window.showQuickPick(servers, { placeHolder: message });
     }
 
     private async promptUser(item: Protocol.WorkflowResponseItem, workflowMap: {}): Promise<boolean> {

--- a/test/commands.test.ts
+++ b/test/commands.test.ts
@@ -73,6 +73,7 @@ suite('Command Handler', () => {
         serverExplorer = new ServersViewTreeDataProvider(stubs.client);
         handler = new CommandHandler(serverExplorer, stubs.client);
         sandbox.stub(serverExplorer);
+        serverExplorer.serverStatus.set('server', serverState);
     });
 
     teardown(() => {
@@ -309,9 +310,16 @@ suite('Command Handler', () => {
     suite('restartServer', () => {
         let startStub: sinon.SinonStub;
         let stopStub: sinon.SinonStub;
+        const startedState: Protocol.ServerState = {
+            deployableStates: [],
+            publishState: 0, server:
+            serverHandle,
+            state: ServerState.STARTED
+        };
 
         setup(() => {
-            sandbox.stub(serverExplorer.serverStatus, 'get').returns(serverState);
+            serverExplorer.serverStatus.set('server', startedState);
+            sandbox.stub(serverExplorer.serverStatus, 'get').returns(startedState);
             startStub = stubs.outgoing.startServerAsync.resolves(status);
             stopStub = stubs.outgoingSync.stopServerSync.resolves(status);
             sandbox.stub(vscode.window, 'showQuickPick').resolves('id');


### PR DESCRIPTION
Got sick of some commands just telling me to use the UI, so I added some logic to make them work on their own and let users select items outside the servers view.

fixes #315 