### PR TITLE
[304] Should show OUTPUT tab as soon as there's new content available

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
       "properties": {
         "vscodeAdapters.showChannelOnServerOutput": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Show Server's output channel when new text added to output stream."
         },
         "java.home": {


### PR DESCRIPTION
it fixes #304 

As agreed with @adietish and @robstryker we just set the default value to true for vscodeAdapters.showChannelOnServerOutput for the moment. We will investigate more ways to manage the output channel later on...

Signed-off-by: Luca Stocchi lstocchi@redhat.com